### PR TITLE
disable society from block viewer

### DIFF
--- a/packages/apps-routing/src/index.ts
+++ b/packages/apps-routing/src/index.ts
@@ -22,7 +22,7 @@ import poll from './poll';
 import rpc from './rpc';
 import settings from './settings';
 import signing from './signing';
-import society from './society';
+// import society from './society';
 import staking from './staking';
 import storage from './storage';
 import sudo from './sudo';
@@ -47,7 +47,7 @@ export default function create (t: TFunction): Routes {
     parachains(t),
     gilt(t),
     assets(t),
-    society(t),
+    // society(t),
     calendar(t),
     contracts(t),
     storage(t),


### PR DESCRIPTION
This PR disables society section from block viewer as it is no longer enabled in the node source