### PR TITLE
disable tech committee from block viewer

### DIFF
--- a/packages/apps-routing/src/index.ts
+++ b/packages/apps-routing/src/index.ts
@@ -26,7 +26,7 @@ import society from './society';
 import staking from './staking';
 import storage from './storage';
 import sudo from './sudo';
-import techcomm from './techcomm';
+// import techcomm from './techcomm';
 import transfer from './transfer';
 import treasury from './treasury';
 
@@ -43,7 +43,7 @@ export default function create (t: TFunction): Routes {
     council(t),
     treasury(t),
     bounties(t),
-    techcomm(t),
+    // techcomm(t),
     parachains(t),
     gilt(t),
     assets(t),


### PR DESCRIPTION
This PR disables Technical Committee from block viewer as we won't have this feature enabled in network yet