### PR TITLE
Set inflation and staked return to zero

### DIFF
--- a/packages/page-staking/src/useSortedTargets.ts
+++ b/packages/page-staking/src/useSortedTargets.ts
@@ -168,7 +168,12 @@ function extractInfo (api: ApiPromise, allAccounts: string[], electedDerive: Der
     .sort((a, b) => a.cmp(b));
   const totalStaked = activeTotals.reduce((total: BN, value) => total.iadd(value), new BN(0));
   const avgStaked = totalStaked.divn(activeTotals.length);
-  const inflation = calcInflation(api, totalStaked, totalIssuance);
+  /**
+   * Since we set inflation to 0 in Node's code we need to be sure that
+   * it will be the same in the BlockViewer until we switch it back
+   */
+  // const inflation = calcInflation(api, totalStaked, totalIssuance);
+  const inflation: ReturnType<typeof calcInflation> = { inflation: 0, stakedReturn: 0 };
 
   // add the explicit stakedReturn
   !avgStaked.isZero() && elected.forEach((e): void => {


### PR DESCRIPTION
We do not get the expected zero value in the UI because the `minInflation` param is set to `0.025` by default and is used to calculate the inflation. We can just change the default `InflationParams` (and set minimum inflation to zero) instead of disabling calculation logic. The inflation calculation is a part of basic UI (polkadot-js/apps).

![image](https://user-images.githubusercontent.com/29141708/116096306-db15e700-a6b1-11eb-9cab-8b29cfccf9f0.png)