### PR TITLE
Add custom types for mainnet

### DIFF
--- a/packages/apps-config/src/api/chain/index.ts
+++ b/packages/apps-config/src/api/chain/index.ts
@@ -6,6 +6,7 @@ import Phala from './phala';
 
 // alphabetical, based on the actual displayed name
 export default {
+  'Cerebellum Mainnet Alpha': Cere,
   'Cerebellum Network Testnet': Cere,
   'Cerebellum Network Testnet Beta': Cere, // For Substrate cluster
   'Local Testnet': Cere, // For Nodes bootstraped from --local chainspec


### PR DESCRIPTION
Custom types with the name "Cerebellum Mainnet Alpha"