### PR TITLE
Updated endpoint for all networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # CHANGELOG
 
-
-## vNext 
+## vNext
 - Added assert for connection string
 - Updated URL validation
+- Updated endpoints for all the networks
 
 ## 0.1.7-cere Jul 20, 2021
 - Added support for External Dev cluster

--- a/packages/apps-config/src/endpoints/production.ts
+++ b/packages/apps-config/src/endpoints/production.ts
@@ -70,7 +70,7 @@ export function createProduction (t: TFunction): LinkOption[] {
       info: 'cere',
       text: t('rpc.cere', 'Cerebellum Mainnet', { ns: 'apps-config' }),
       providers: {
-        'Cerebellum Network': 'wss://archive.mainnet.cere.network:9945'
+        'Cerebellum Network': 'wss://rpc.mainnet.cere.network:9945'
       }
     },
     {

--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -29,21 +29,21 @@ export function createTesting (t: TFunction): LinkOption[] {
       info: 'cere',
       text: t('rpc.cere', 'Cerebellum Devnet', { ns: 'apps-config' }),
       providers: {
-        'Cerebellum Network': 'wss://rpc.testnet.dev.cere.network:9945'
+        'Cerebellum Network': 'wss://rpc.devnet.cere.network:9945'
       }
     },
     {
       info: 'cere',
       text: t('rpc.cere', 'Cerebellum Testnet', { ns: 'apps-config' }),
       providers: {
-        'Cerebellum Network': 'wss://rpc.mainnet.stage.cere.network:9945'
+        'Cerebellum Network': 'wss://rpc.testnet.cere.network:9945'
       }
     },
     {
       info: 'cere',
       text: t('rpc.cere', 'Cerebellum QAnet', { ns: 'apps-config' }),
       providers: {
-        'Cerebellum Network': 'wss://rpc.testnet.cere.network:9945'
+        'Cerebellum Network': 'wss://rpc.qanet.cere.network:9945'
       }
     },
     {


### PR DESCRIPTION
Updated endpoints for below networks
1. Mainnet  -- wss://rpc.mainnet.cere.network:9945
2. Devnet  -- wss://rpc.devnet.cere.network:9945
3. Testnet -- wss://rpc.testnet.cere.network:9945
4. Qanet  -- wss://rpc.qanet.cere.network:9945